### PR TITLE
Table subset checking only works when checking in the same order starting on the first row

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
         "behat/behat": "^3.4",
         "behat/mink-extension": "^2.3",
         "php": "~7.1",
-        "phpunit/phpunit": "^4.0|^5.0|^6.0|^7.0",
         "symfony/dependency-injection": "^2.1|^3.0|^4.0",
         "symfony/dom-crawler": "^2.8|^3.0|^4.0",
         "symfony/event-dispatcher": "^2.0|^3.0|^4.0"

--- a/features/tables.feature
+++ b/features/tables.feature
@@ -45,14 +45,17 @@ Feature: Inspecting HTML tables
       | Header 1    | Header 2    | Header 3    |
       | Row 1 Col 1 | Row 1 Col 2 | Row 1 Col 3 |
       | Row 2 Col 1 | Row 2 Col 2 | Row 2 Col 3 |
-    # Check that we can verify subsets of the table.
+    # Check that we can verify subsets of the table, regardless of the order in which they appear.
     And the simple table should contain:
-      | Header 1    | Header 2    |
-      | Row 1 Col 1 | Row 1 Col 2 |
+      | Header 1    | Header 2    | Header 3    |
+      | Row 1 Col 1 | Row 1 Col 2 | Row 1 Col 3 |
+    And the simple table should contain:
+      | Header 1    | Header 3    |
+      | Row 2 Col 1 | Row 2 Col 3 |
     And the simple table should contain:
       | Header 1    |
-      | Row 1 Col 1 |
       | Row 2 Col 1 |
+      | Row 1 Col 1 |
 
     # The second table has 2 columns, of which the first is a vertical header.
     And I should see the Algarve table

--- a/src/AssertArraySubset.php
+++ b/src/AssertArraySubset.php
@@ -1,0 +1,137 @@
+<?php
+/*
+ * This file is based on code from PHPUnit.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace LoversOfBehat\TableExtension;
+
+use LoversOfBehat\TableExtension\Exception\NoArraySubsetException;
+
+/**
+ * Asserts that an array has a specified subset.
+ *
+ * This is based on the array subset constraint from PHPUnit.
+ *
+ * @see \PHPUnit\Framework\Constraint\ArraySubset
+ */
+class AssertArraySubset
+{
+    /**
+     * @var array
+     */
+    private $subset;
+
+    /**
+     * @var bool
+     */
+    private $strict;
+
+    public function __construct(array $subset, bool $strict = false)
+    {
+        $this->strict = $strict;
+        $this->subset = $subset;
+    }
+
+    /**
+     * Evaluates the constraint for parameter $other
+     *
+     * @param array $other
+     *   The array to compare.
+     *
+     * @throws NoArraySubsetException
+     *   Thrown when the subset is not part of the passed array.
+     */
+    public function evaluate(array $other): void
+    {
+        $intersect = $this->arrayIntersectRecursive($other, $this->subset);
+        $this->deepSort($intersect);
+        $this->deepSort($this->subset);
+
+        $result = $this->compare($intersect, $this->subset);
+
+        if (!$result) {
+            throw new NoArraySubsetException();
+        }
+    }
+
+    private function isAssociative(array $array): bool
+    {
+        return \array_reduce(\array_keys($array), function (bool $carry, $key): bool {
+            return $carry || \is_string($key);
+        }, false);
+    }
+
+    private function compare($first, $second): bool
+    {
+        return $this->strict ? $first === $second : $first == $second;
+    }
+
+    private function deepSort(array &$array): void
+    {
+        foreach ($array as &$value) {
+            if (\is_array($value)) {
+                $this->deepSort($value);
+            }
+        }
+
+        if ($this->isAssociative($array)) {
+            \ksort($array);
+        } else {
+            \sort($array);
+        }
+    }
+
+    private function arrayIntersectRecursive(array $array, array $subset): array
+    {
+        $intersect = [];
+
+        if ($this->isAssociative($subset)) {
+            // If the subset is an associative array, get the intersection while
+            // preserving the keys.
+            foreach ($subset as $key => $subset_value) {
+                if (\array_key_exists($key, $array)) {
+                    $array_value = $array[$key];
+
+                    if (\is_array($subset_value) && \is_array($array_value)) {
+                        $intersect[$key] = $this->arrayIntersectRecursive($array_value, $subset_value);
+                    } elseif ($this->compare($subset_value, $array_value)) {
+                        $intersect[$key] = $array_value;
+                    }
+                }
+            }
+        } else {
+            // If the subset is an indexed array, loop over all entries in the
+            // haystack and check if they match the ones in the subset.
+            foreach ($array as $array_key => $array_value) {
+                if (\is_array($array_value)) {
+                    foreach (array_diff_key($subset, $intersect) as $key => $subset_value) {
+                        if (\is_array($subset_value)) {
+                            $recursed = $this->arrayIntersectRecursive($array_value, $subset_value);
+
+                            if (!empty($recursed)) {
+                                $intersect[$key] = $recursed;
+
+                                break;
+                            }
+                        }
+                    }
+                } else {
+                    // Skip values that have already been matched.
+                    foreach (array_diff_key($subset, $intersect) as $key => $subset_value) {
+                        if (!\is_array($subset_value) && $this->compare($subset_value, $array_value)) {
+                            $intersect[$key] = $array_value;
+
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $intersect;
+    }
+}

--- a/src/Context/TableContext.php
+++ b/src/Context/TableContext.php
@@ -5,8 +5,9 @@ declare(strict_types = 1);
 namespace LoversOfBehat\TableExtension\Context;
 
 use Behat\Gherkin\Node\TableNode;
+use LoversOfBehat\TableExtension\AssertArraySubset;
+use LoversOfBehat\TableExtension\Exception\NoArraySubsetException;
 use LoversOfBehat\TableExtension\Exception\TableNotFoundException;
-use PHPUnit\Framework\Assert;
 
 class TableContext extends RawTableContext
 {
@@ -168,7 +169,7 @@ class TableContext extends RawTableContext
     public function assertTableData(string $name, TableNode $data): void
     {
         $table = $this->getTable($name);
-        Assert::assertArraySubset($data->getRows(), $table->getData());
+        $this->assertArraySubset($data->getRows(), $table->getData());
     }
 
     /**
@@ -184,7 +185,7 @@ class TableContext extends RawTableContext
     public function assertTableColumnData(string $name, TableNode $data): void
     {
         $table = $this->getTable($name);
-        Assert::assertArraySubset($data->getColumnsHash(), array_values($table->getColumnData($data->getRow(0))));
+        $this->assertArraySubset($data->getColumnsHash(), array_values($table->getColumnData($data->getRow(0))));
     }
 
     /**
@@ -200,7 +201,7 @@ class TableContext extends RawTableContext
     public function assertTableRowData(string $name, TableNode $data): void
     {
         $table = $this->getTable($name);
-        Assert::assertArraySubset($data->getRowsHash(), $table->getRowData($data->getColumn(0)));
+        $this->assertArraySubset($data->getRowsHash(), $table->getRowData($data->getColumn(0)));
     }
 
     /**
@@ -235,5 +236,23 @@ class TableContext extends RawTableContext
                 throw new \RuntimeException("A table with $count rows is present on the page, but should not be.");
             }
         }
+    }
+
+    /**
+     * Checks that the given array contains the given subset.
+     *
+     * @param array $subset
+     *   The subset that is expected to exist in the array.
+     * @param array $array
+     *   The array.
+     * @param bool $strict
+     *   Whether to perform strict data type checking when comparing the two arrays.
+     *
+     * @throws NoArraySubsetException
+     */
+    protected function assertArraySubset(array $subset, array $array, bool $strict = false): void
+    {
+        $assert = new AssertArraySubset($subset, $strict);
+        $assert->evaluate($array);
     }
 }

--- a/src/Exception/NoArraySubsetException.php
+++ b/src/Exception/NoArraySubsetException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace LoversOfBehat\TableExtension\Exception;
+
+class NoArraySubsetException extends \LogicException
+{
+}


### PR DESCRIPTION
We are using the `AssertArraySubset` constraint from PHPUnit to check if our tables match but this has known limitations for working with indexed arrays, which is what we are using. This means that it only works if we are checking starting with the first row in the table, and with all results in the exact same order. Support for indexed arrays has been added in the latest dev branch of PHPUnit, but it has not been released yet and will not be backported to older versions of PHPUnit.

I don't want to limit users to just the latest version of PHPUnit so let's port the fix to a standalone class.