### PR TITLE
Fix matching of tables that contain partially duplicated data

### DIFF
--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -16,3 +16,4 @@ default:
         'Population data': 'table.countries'
         'Employees': '.employees > table'
         'Mad spanner': '.madspans'
+        'User roles': '.roles'

--- a/features/tables.feature
+++ b/features/tables.feature
@@ -6,7 +6,7 @@ Feature: Inspecting HTML tables
   Scenario: Check if any table on the page matches certain characteristics
     Given I am on the homepage
     Then I should see a table
-    And I should see 5 tables
+    And I should see 6 tables
 
     And I should see a table with 2 columns
     And I should see a table with 3 columns
@@ -147,3 +147,16 @@ Feature: Inspecting HTML tables
       |    |    | 3C |    |    |    |
       | 4A | 4B |    | 4D |    |    |
       | 5A |    | 5C |    |    |    |
+
+    # The sixth table contains cells with the same content in different rows.
+    And I should see the "User roles" table
+    And the "User roles" table should have 3 columns
+    And the "User roles" table should have 7 rows
+    And the "User roles" table should contain the following columns:
+      | Group       | Username          | Role          |
+      | Engineering | Najib Randall     | administrator |
+      | Support     | Victor Otto       | administrator |
+      | Engineering | Melor Vescovi     | moderator     |
+      | Engineering | Panteleimon Kita  | moderator     |
+      | Support     | Victor Otto       | moderator     |
+      | Support     | Melissa Kevorkian | moderator     |

--- a/fixtures/index.html
+++ b/fixtures/index.html
@@ -183,5 +183,46 @@
         <td colspan="3">5C</td>
       </tr>
     </table>
+    <table class="roles">
+      <thead>
+        <tr>
+          <th>Group</th>
+          <th>Username</th>
+          <th>Role</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Engineering</td>
+          <td>Najib Randall</td>
+          <td>administrator</td>
+        </tr>
+        <tr>
+          <td>Support</td>
+          <td>Victor Otto</td>
+          <td>administrator</td>
+        </tr>
+        <tr>
+          <td>Engineering</td>
+          <td>Melor Vescovi</td>
+          <td>moderator</td>
+        </tr>
+        <tr>
+          <td>Support</td>
+          <td>Victor Otto</td>
+          <td>moderator</td>
+        </tr>
+        <tr>
+          <td>Engineering</td>
+          <td>Panteleimon Kita</td>
+          <td>moderator</td>
+        </tr>
+        <tr>
+          <td>Support</td>
+          <td>Melissa Kevorkian</td>
+          <td>moderator</td>
+        </tr>
+      </tbody>
+    </table>
   </body>
 </html>

--- a/src/AssertArraySubset.php
+++ b/src/AssertArraySubset.php
@@ -132,6 +132,7 @@ class AssertArraySubset
             }
         }
 
-        return $intersect;
+        // Only return the result if it fully matches the subset.
+        return count($subset) == count($intersect) ? $intersect : [];
     }
 }


### PR DESCRIPTION
When a table contains data that is partially duplicated over multiple rows (e.g. the first two column has the same data in both rows, but the other columns contain different data), this is causing false negatives.