### PR TITLE
Add a step to check an arbitrary column of a table.

### DIFF
--- a/features/tables.feature
+++ b/features/tables.feature
@@ -58,6 +58,10 @@ Feature: Inspecting HTML tables
       | Header 1    |
       | Row 2 Col 1 |
       | Row 1 Col 1 |
+    And the simple table should contain a column with the following data:
+      | Header 1    |
+      | Row 1 Col 1 |
+      | Row 2 Col 1 |
     And the simple table should not contain:
       | A squirrel |
 

--- a/src/Context/TableContext.php
+++ b/src/Context/TableContext.php
@@ -284,6 +284,11 @@ class TableContext extends RawTableContext
         // Convert rows of columns to columns of rows.
         $columns = array_map(null, ...$rows);
         foreach ($columns as $column) {
+            if (!empty($column) && !is_array($column)) {
+                // The array_map() above will convert a single column of data to
+                // a single value, so we need to convert it back to an array.
+                $column = [$column];
+            }
             try {
                 if ($data->getColumn(0) === $column) {
                     return;

--- a/src/Context/TableContext.php
+++ b/src/Context/TableContext.php
@@ -268,6 +268,33 @@ class TableContext extends RawTableContext
     }
 
     /**
+     * Checks that the given table contains any column with the given data
+     *
+     * @param string $name
+     *   The human readable name for the table.
+     * @param TableNode $data
+     *   The data that is expected to be present in the table.
+     *
+     * @Then the :name table should contain a column with the following data:
+     */
+    public function assertTableAnyColumnData(string $name, TableNode $data): void
+    {
+        $table = $this->getTable($name);
+        $rows = $table->getData();
+        // Convert rows of columns to columns of rows.
+        $columns = array_map(null, ...$rows);
+        foreach ($columns as $column) {
+            try {
+                if ($data->getColumn(0) === $column) {
+                    return;
+                }
+            } catch (NoArraySubsetException $e) {
+            }
+        }
+        throw new \RuntimeException("No column was found with the exact row data given.");
+    }
+
+    /**
      * Checks that the given table does not contain the given non-consecutive columns, identified by headers.
      *
      * @param string $name


### PR DESCRIPTION
I am adding a step to check for an arbitrary column. The reason is that there is already a check for that, but it requires a header. The problem is that not all tables have headers. Thus, I have a step that goes through the columns and asserts the contents of _a_ column.